### PR TITLE
Sweep over more potential planets in catascript

### DIFF
--- a/catascript/catascript.py
+++ b/catascript/catascript.py
@@ -183,10 +183,10 @@ def catascript():
         print("Done : catascript - recomputed entries")
     
     else:
-
+        # Only processing confirmed catalog        
         process_confirmed()
         
-        print("Done : catascript - no new computing performed")
+        print("Done : catascript - only confirmed planets catalog processed again")
 
 if __name__ == "__main__":
     catascript()

--- a/catascript/catascript.py
+++ b/catascript/catascript.py
@@ -98,32 +98,6 @@ def check_in_TICS_dict(TIC_in_catalog, TICS_dict):
     else:
         return ( (False, ("", []))) #we return False and default values
 
-def check_exists_other_ID(catalog_line):
-    """
-    Checks if the given line has another ID than a TIC
-
-    :param catalog_line: line of catalog currently being examined
-    :type catalog_line: dict
-
-    :returns: boolean indicating at least one other ID found, (name of mission ID, ID) dictionnary of found IDs
-    :rtype: (bool, dict) tuple
-    """
-    #Getting the fields corresponding to ids
-    list_of_ids = (os.getenv("OTHER_MISSIONS_IDS")).split(',')
-
-    #Dictionnary of found other ids
-    found_ids = {}
-    flag = False
-
-    #Checks for the existence of other ids
-    for id_mission_name in list_of_ids:
-        if catalog_line[id_mission_name] != None:
-            flag = flag or True
-            found_ids[id_mission_name] = catalog_line[id_mission_name]
-    
-    #Results
-    return((flag, found_ids))
-
 #Database relation functions
 def initialize_database():
     """
@@ -194,17 +168,12 @@ def catascript():
                     #check if match with a TIC with known light curve
                     (TIC_in_dict, dict_values) = check_in_TICS_dict(TIC_in_catalog, TICS_dict)
                     if TIC_in_dict:
+                        # add values extracted from the tic stored dictionnary in the catalog line to be stored in the database
+                        catalog_line_values['SECTOR'] = dict_values[0]['SECTOR']
+                        catalog_line_values['path'] = dict_values[0]['path']
 
-                        #check for existence of other missions IDs
-                        (exists_other_ids, corresponding_ids) = check_exists_other_ID(catalog_line_values)
-                        if exists_other_ids:
-
-                            # add values extracted from the tic stored dictionnary in the catalog line to be stored in the database
-                            catalog_line_values['SECTOR'] = dict_values[0]['SECTOR']
-                            catalog_line_values['path'] = dict_values[0]['path']
-
-                            # add entry to database
-                            add_entry_to_database(catalog_line_values)
+                        # add entry to database
+                        add_entry_to_database(catalog_line_values)
 
                 print("Processing {} : Done".format(catalog_file))
 
@@ -214,6 +183,9 @@ def catascript():
         print("Done : catascript - recomputed entries")
     
     else:
+
+        process_confirmed()
+        
         print("Done : catascript - no new computing performed")
 
 if __name__ == "__main__":

--- a/catascript/confirmed.py
+++ b/catascript/confirmed.py
@@ -61,9 +61,8 @@ def checks_star_exists_in_database_and_update(processed_catalog_line):
 
         #Database modifications
         if search_for_HIP:
-            print("____")
-            print("HIP : Modifying entryf for : {}".format(processed_catalog_line))
-            print("____")
+            print(" ")
+            print("HIP : \n Modifying entry for : {}".format(processed_catalog_line))
             search_for_HIP[0].already_confirmed = True
              
     #Else, we search by ra and dec (in degrees in the database)
@@ -77,9 +76,8 @@ def checks_star_exists_in_database_and_update(processed_catalog_line):
 
         #Database modifications
         if (search_for_Dec_and_Ra):
-            print("____")
-            print("Dec ; Ra : Modifying entry for : {}".format(processed_catalog_line))
-            print("____")
+            print(" ")
+            print("Dec/Ra : \n Modifying entry for : {}".format(processed_catalog_line))
             search_for_Dec_and_Ra[0].already_confirmed = True
              
     session.commit()


### PR DESCRIPTION
The purpose of this MR is to remove some unused checks in the adding of entries in the database (Catalog) and improve the printing in the confirmed script.

In addition to this, a new catalog should be used, with all means of detection possible, and not restricting to transits method